### PR TITLE
Добавление альтернативного текста к изображениям

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,18 +32,18 @@
             <section class="mt-6">
                 <h2>Images from <a href="https://pixabay.com">Pixabay</a></h2>
                 <div>
-                    <img src="img/pixabay-foal.jpg" class="rounded" alt="">
-                    <img src="img/pixabay-lion.jpg" class="rounded" alt="">
-                    <img src="img/pixabay-wolf.jpg" class="rounded" alt="">
+                    <img src="img/pixabay-foal.jpg" class="rounded" alt="foal">
+                    <img src="img/pixabay-lion.jpg" class="rounded" alt="lion">
+                    <img src="img/pixabay-wolf.jpg" class="rounded" alt="wolf">
                 </div>
             </section>
 
             <section class="mt-6">
                 <h2>Images from <a href="https://pexels.com">Pexels</a></h2>
                 <div>
-                    <img src="img/pexels-drops.jpeg" class="rounded" alt="">
-                    <img src="img/pexels-mountains.jpeg" class="rounded" alt="">
-                    <img src="img/pexels-railway.jpeg" class="rounded" alt="">
+                    <img src="img/pexels-drops.jpeg" class="rounded" alt="drops">
+                    <img src="img/pexels-mountains.jpeg" class="rounded" alt="mountains">
+                    <img src="img/pexels-railway.jpeg" class="rounded" alt="railway">
                 </div>
             </section>
 


### PR DESCRIPTION
В файле index.html у изображений отсутствовали значение атрибута alt, в связи с этим скрин-ридеры не могут корректно "прочитать" изображения. исправлена эта ошибка