### PR TITLE
Отсутствует атрибут alt в изображениях

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,18 +32,18 @@
             <section class="mt-6">
                 <h2>Images from <a href="https://pixabay.com">Pixabay</a></h2>
                 <div>
-                    <img src="img/pixabay-foal.jpg" class="rounded" alt="">
-                    <img src="img/pixabay-lion.jpg" class="rounded" alt="">
-                    <img src="img/pixabay-wolf.jpg" class="rounded" alt="">
+                    <img src="img/pixabay-foal.jpg" class="rounded" alt="Лошадь">
+                    <img src="img/pixabay-lion.jpg" class="rounded" alt="Лев">
+                    <img src="img/pixabay-wolf.jpg" class="rounded" alt="Волк">
                 </div>
             </section>
 
             <section class="mt-6">
                 <h2>Images from <a href="https://pexels.com">Pexels</a></h2>
                 <div>
-                    <img src="img/pexels-drops.jpeg" class="rounded" alt="">
-                    <img src="img/pexels-mountains.jpeg" class="rounded" alt="">
-                    <img src="img/pexels-railway.jpeg" class="rounded" alt="">
+                    <img src="img/pexels-drops.jpeg" class="rounded" alt="Капли воды">
+                    <img src="img/pexels-mountains.jpeg" class="rounded" alt="Горы">
+                    <img src="img/pexels-railway.jpeg" class="rounded" alt="Железная дорога">
                 </div>
             </section>
 


### PR DESCRIPTION
В файле index.html у изображений отсутствует значение атрибута alt, в связи с этим скрин-ридеры не могут корректно "прочитать" изображения.